### PR TITLE
feat(models): register additional model backends

### DIFF
--- a/src/google/adk/models/__init__.py
+++ b/src/google/adk/models/__init__.py
@@ -26,6 +26,22 @@ __all__ = [
     'LLMRegistry',
 ]
 
+LLMRegistry.register(Gemini)
 
-for regex in Gemini.supported_models():
-  LLMRegistry.register(Gemini)
+try:  # pragma: no cover - optional dependency
+  from .anthropic_llm import Claude
+except ModuleNotFoundError:  # pragma: no cover
+  pass
+else:  # pragma: no cover
+  __all__.append('Claude')
+  LLMRegistry.register(Claude)
+
+try:  # pragma: no cover - optional dependency
+  from .lite_llm import LiteLlm
+except ModuleNotFoundError:  # pragma: no cover
+  pass
+else:  # pragma: no cover
+  __all__.append('LiteLlm')
+  LLMRegistry.register(LiteLlm)
+
+__all__.sort()

--- a/src/google/adk/models/lite_llm.py
+++ b/src/google/adk/models/lite_llm.py
@@ -921,13 +921,13 @@ class LiteLlm(BaseLlm):
   @classmethod
   @override
   def supported_models(cls) -> list[str]:
-    """Provides the list of supported models.
+    """Provides a catch-all for LiteLlm supported models.
 
-    LiteLlm supports all models supported by litellm. We do not keep track of
-    these models here. So we return an empty list.
+    LiteLlm can proxy to any model supported by LiteLLM. To allow fallback to
+    this backend, we expose a regex that matches any model name.
 
     Returns:
-      A list of supported models.
+      A list containing a single regex that matches any model name.
     """
 
-    return []
+    return [r".*"]

--- a/tests/unittests/models/test_models.py
+++ b/tests/unittests/models/test_models.py
@@ -15,7 +15,7 @@
 from google.adk import models
 from google.adk.models.anthropic_llm import Claude
 from google.adk.models.google_llm import Gemini
-from google.adk.models.registry import LLMRegistry
+from google.adk.models.lite_llm import LiteLlm
 import pytest
 
 
@@ -51,12 +51,8 @@ def test_match_gemini_family(model_name):
     ],
 )
 def test_match_claude_family(model_name):
-  LLMRegistry.register(Claude)
-
   assert models.LLMRegistry.resolve(model_name) is Claude
 
 
-def test_non_exist_model():
-  with pytest.raises(ValueError) as e_info:
-    models.LLMRegistry.resolve('non-exist-model')
-  assert 'Model non-exist-model not found.' in str(e_info.value)
+def test_fallback_to_litellm():
+  assert models.LLMRegistry.resolve('gpt-4o') is LiteLlm


### PR DESCRIPTION
## Summary
- auto-register Claude and LiteLlm backends in model registry
- expose catch-all pattern for LiteLlm model resolution
- add tests for Claude resolution and LiteLlm fallback

## Testing
- `./autoformat.sh`
- `pytest tests/unittests/models/test_models.py`
- `pytest tests/unittests` *(fails: 19 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bd75b6f1a0832084dcc14ed4b68984