### PR TITLE
feat: add software agent pipeline with docker tools #non-breaking

### DIFF
--- a/software_agent/README.md
+++ b/software_agent/README.md
@@ -1,0 +1,32 @@
+# Software Agent Sample
+
+This sample demonstrates a sequential pipeline that generates Python code,
+writes it to a file, creates a Dockerfile, then builds and runs the resulting
+container.
+
+## Agents
+
+The pipeline is defined in `root_agent.yaml` and executes five sub-agents in
+order:
+
+1. `code_generator_agent.yaml` – produces Python source code.
+2. `file_writer_agent.yaml` – saves the generated code to `generated_code.py`
+   using the `write_files` tool.
+3. `dockerfile_generator_agent.yaml` – writes a Dockerfile that exposes port
+   8000 and runs `generated_code.py` on startup.
+4. `docker_builder_agent.yaml` – builds a Docker image with the `docker_build`
+   tool.
+5. `docker_runner_agent.yaml` – runs the image via the `run_command` tool using
+   the exposed port.
+
+## Tools
+
+Tools for this sample live in `software_agent/tools` and are referenced with the
+`software_agent.tools` module path:
+
+- `write_files`: writes contents to disk.
+- `docker_build`: invokes `docker build`.
+- `run_command`: executes arbitrary shell commands.
+
+Run the pipeline with ADK's runner to see the generated code executed inside a
+Docker container.

--- a/software_agent/README.md
+++ b/software_agent/README.md
@@ -19,6 +19,8 @@ order:
 5. `docker_runner_agent.yaml` – runs the image via the `run_command` tool using
    the exposed port.
 
+All LLM agents in this pipeline use the `gemini-2.5-flash` model.
+
 ## Tools
 
 Tools for this sample live in `software_agent/tools` and are referenced with the

--- a/software_agent/__init__.py
+++ b/software_agent/__init__.py
@@ -1,0 +1,18 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sample pipeline for generating and running Dockerized code."""
+
+from __future__ import annotations
+

--- a/software_agent/root_agent.yaml
+++ b/software_agent/root_agent.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/google/adk-python/refs/heads/main/src/google/adk/agents/config_schemas/AgentConfig.json
+agent_class: SequentialAgent
+name: CodeToDockerPipeline
+description: Generates Python code, writes it to a file, creates a Dockerfile, builds and runs the image.
+sub_agents:
+  - config_path: sub_agents/code_generator_agent.yaml
+  - config_path: sub_agents/file_writer_agent.yaml
+  - config_path: sub_agents/dockerfile_generator_agent.yaml
+  - config_path: sub_agents/docker_builder_agent.yaml
+  - config_path: sub_agents/docker_runner_agent.yaml

--- a/software_agent/sub_agents/code_generator_agent.yaml
+++ b/software_agent/sub_agents/code_generator_agent.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/google/adk-python/refs/heads/main/src/google/adk/agents/config_schemas/AgentConfig.json
+agent_class: LlmAgent
+name: CodeGeneratorAgent
+model: gemini-2.0-flash
+description: Generates plain Python code based on user request.
+instruction: |
+  You are a Python code generator.
+  Based only on the user's request, write Python code that fulfills it.
+  Output only the complete Python code block enclosed in triple backticks (```python ... ```).
+output_key: generated_code

--- a/software_agent/sub_agents/code_generator_agent.yaml
+++ b/software_agent/sub_agents/code_generator_agent.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/google/adk-python/refs/heads/main/src/google/adk/agents/config_schemas/AgentConfig.json
 agent_class: LlmAgent
 name: CodeGeneratorAgent
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 description: Generates plain Python code based on user request.
 instruction: |
   You are a Python code generator.

--- a/software_agent/sub_agents/docker_builder_agent.yaml
+++ b/software_agent/sub_agents/docker_builder_agent.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/google/adk-python/refs/heads/main/src/google/adk/agents/config_schemas/AgentConfig.json
 agent_class: LlmAgent
 name: DockerBuilderAgent
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 description: Builds a Docker image from the generated Dockerfile.
 instruction: |
   Use {dockerfile_info} to find the "dockerfile_path" value.

--- a/software_agent/sub_agents/docker_builder_agent.yaml
+++ b/software_agent/sub_agents/docker_builder_agent.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/google/adk-python/refs/heads/main/src/google/adk/agents/config_schemas/AgentConfig.json
+agent_class: LlmAgent
+name: DockerBuilderAgent
+model: gemini-2.0-flash
+description: Builds a Docker image from the generated Dockerfile.
+instruction: |
+  Use {dockerfile_info} to find the "dockerfile_path" value.
+  Call the docker_build tool with:
+    context_path: directory containing that file
+    image_tag: "my-app:latest"
+  After running the tool, respond with "Docker image built."
+tools:
+  - name: software_agent.tools.docker_build
+output_key: docker_build_result

--- a/software_agent/sub_agents/docker_runner_agent.yaml
+++ b/software_agent/sub_agents/docker_runner_agent.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/google/adk-python/refs/heads/main/src/google/adk/agents/config_schemas/AgentConfig.json
 agent_class: LlmAgent
 name: DockerRunnerAgent
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 description: Runs the Docker image produced by earlier steps.
 instruction: |
   You receive JSON in {dockerfile_info} containing the exposed "port".

--- a/software_agent/sub_agents/docker_runner_agent.yaml
+++ b/software_agent/sub_agents/docker_runner_agent.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/google/adk-python/refs/heads/main/src/google/adk/agents/config_schemas/AgentConfig.json
+agent_class: LlmAgent
+name: DockerRunnerAgent
+model: gemini-2.0-flash
+description: Runs the Docker image produced by earlier steps.
+instruction: |
+  You receive JSON in {dockerfile_info} containing the exposed "port".
+  Parse the port and start the container by calling the run_command tool:
+    command: ["docker", "run", "--rm", "-p", "<port>:<port>", "my-app:latest"]
+  After the container exits, respond with "Docker container executed on port <port>."
+tools:
+  - name: software_agent.tools.run_command
+output_key: docker_run_result

--- a/software_agent/sub_agents/dockerfile_generator_agent.yaml
+++ b/software_agent/sub_agents/dockerfile_generator_agent.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/google/adk-python/refs/heads/main/src/google/adk/agents/config_schemas/AgentConfig.json
+agent_class: LlmAgent
+name: DockerfileGeneratorAgent
+model: gemini-2.0-flash
+description: Generates a Dockerfile for the produced Python code.
+instruction: |
+  You receive the path to the Python file in {generated_file_path}.
+  Create a Dockerfile that:
+    - Uses "python:3.11-slim" as the base image.
+    - Copies {generated_file_path} into "/app".
+    - Sets the working directory to "/app".
+    - Exposes port 8000.
+    - Defines the entrypoint "python {generated_file_path}".
+  Use the write_files tool to save the Dockerfile at "Dockerfile".
+  After running the tool, respond with the JSON:
+    {"dockerfile_path": "Dockerfile", "port": "8000"}
+tools:
+  - name: software_agent.tools.write_files
+output_key: dockerfile_info

--- a/software_agent/sub_agents/dockerfile_generator_agent.yaml
+++ b/software_agent/sub_agents/dockerfile_generator_agent.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/google/adk-python/refs/heads/main/src/google/adk/agents/config_schemas/AgentConfig.json
 agent_class: LlmAgent
 name: DockerfileGeneratorAgent
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 description: Generates a Dockerfile for the produced Python code.
 instruction: |
   You receive the path to the Python file in {generated_file_path}.

--- a/software_agent/sub_agents/file_writer_agent.yaml
+++ b/software_agent/sub_agents/file_writer_agent.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/google/adk-python/refs/heads/main/src/google/adk/agents/config_schemas/AgentConfig.json
+agent_class: LlmAgent
+name: FileWriterAgent
+model: gemini-2.0-flash
+description: Creates a Python file from provided code.
+instruction: |
+  You receive Python code in {generated_code}.
+  Use the write_files tool to save it to "generated_code.py".
+  Call the tool with:
+    files: {"generated_code.py": "{generated_code}"}
+  After running the tool, respond only with the text "generated_code.py".
+tools:
+  - name: software_agent.tools.write_files
+output_key: generated_file_path

--- a/software_agent/sub_agents/file_writer_agent.yaml
+++ b/software_agent/sub_agents/file_writer_agent.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/google/adk-python/refs/heads/main/src/google/adk/agents/config_schemas/AgentConfig.json
 agent_class: LlmAgent
 name: FileWriterAgent
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 description: Creates a Python file from provided code.
 instruction: |
   You receive Python code in {generated_code}.

--- a/software_agent/tools/__init__.py
+++ b/software_agent/tools/__init__.py
@@ -1,0 +1,27 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tools for the software agent sample."""
+
+from __future__ import annotations
+
+from .docker_build import docker_build
+from .run_command import run_command
+from .write_files import write_files
+
+__all__ = [
+    "docker_build",
+    "run_command",
+    "write_files",
+]

--- a/software_agent/tools/docker_build.py
+++ b/software_agent/tools/docker_build.py
@@ -1,0 +1,47 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Docker image build tool for the software agent sample."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Any, Dict
+
+
+async def docker_build(context_path: str, image_tag: str) -> Dict[str, Any]:
+  """Builds a Docker image from the given context.
+
+  Args:
+    context_path: Directory used as the Docker build context.
+    image_tag: Tag for the resulting image (for example, "my-app:latest").
+
+  Returns:
+    Dict containing success flag, stdout, stderr and return code.
+  """
+  try:
+    proc = subprocess.run(
+        ["docker", "build", "-t", image_tag, context_path],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return {
+        "success": proc.returncode == 0,
+        "stdout": proc.stdout,
+        "stderr": proc.stderr,
+        "returncode": proc.returncode,
+    }
+  except Exception as exc:  # pylint: disable=broad-except
+    return {"success": False, "error": str(exc)}

--- a/software_agent/tools/run_command.py
+++ b/software_agent/tools/run_command.py
@@ -1,0 +1,41 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tool to execute shell commands."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Any, Dict, List
+
+
+async def run_command(command: List[str]) -> Dict[str, Any]:
+  """Runs a shell command and captures its output.
+
+  Args:
+    command: Sequence of command arguments to execute.
+
+  Returns:
+    Dict with success flag, stdout, stderr, return code and optional error.
+  """
+  try:
+    proc = subprocess.run(command, capture_output=True, text=True, check=False)
+    return {
+        "success": proc.returncode == 0,
+        "stdout": proc.stdout,
+        "stderr": proc.stderr,
+        "returncode": proc.returncode,
+    }
+  except Exception as exc:  # pylint: disable=broad-except
+    return {"success": False, "error": str(exc)}

--- a/software_agent/tools/write_files.py
+++ b/software_agent/tools/write_files.py
@@ -1,0 +1,122 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""File writing tool for Agent Builder Assistant."""
+
+from datetime import datetime
+from pathlib import Path
+import shutil
+from typing import Any
+from typing import Dict
+
+
+async def write_files(
+    files: Dict[str, str],
+    create_backup: bool = False,
+    create_directories: bool = True,
+) -> Dict[str, Any]:
+  """Write content to multiple files with optional backup creation.
+
+  This tool writes content to multiple files. It's designed for creating
+  Python tools, callbacks, configuration files, and other code files.
+
+  Args:
+    files: Dict mapping file_path to content to write
+    create_backup: Whether to create backups of existing files (default: False)
+    create_directories: Whether to create parent directories (default: True)
+
+  Returns:
+    Dict containing write operation results:
+      - success: bool indicating if all writes succeeded
+      - files: dict mapping file_path to file info:
+        - file_size: size of written file in bytes
+        - existed_before: bool indicating if file existed before write
+        - backup_created: bool indicating if backup was created
+        - backup_path: path to backup file if created
+        - error: error message if write failed for this file
+      - successful_writes: number of files written successfully
+      - total_files: total number of files requested
+      - errors: list of general error messages
+  """
+  try:
+    result = {
+        "success": True,
+        "files": {},
+        "successful_writes": 0,
+        "total_files": len(files),
+        "errors": [],
+    }
+
+    for file_path, content in files.items():
+      file_path_obj = Path(file_path).resolve()
+      file_info = {
+          "file_size": 0,
+          "existed_before": False,
+          "backup_created": False,
+          "backup_path": None,
+          "error": None,
+      }
+
+      try:
+        # Check if file already exists
+        file_info["existed_before"] = file_path_obj.exists()
+
+        # Create parent directories if needed
+        if create_directories:
+          file_path_obj.parent.mkdir(parents=True, exist_ok=True)
+
+        # Create backup if requested and file exists
+        if create_backup and file_info["existed_before"]:
+          timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+          backup_path = file_path_obj.with_suffix(
+              f".backup_{timestamp}{file_path_obj.suffix}"
+          )
+          try:
+            shutil.copy2(file_path_obj, backup_path)
+            file_info["backup_created"] = True
+            file_info["backup_path"] = str(backup_path)
+          except Exception as e:
+            file_info["error"] = f"Failed to create backup: {str(e)}"
+            result["success"] = False
+            result["files"][str(file_path_obj)] = file_info
+            continue
+
+        # Write content to file
+        with open(file_path_obj, "w", encoding="utf-8") as f:
+          f.write(content)
+
+        # Verify write and get file size
+        if file_path_obj.exists():
+          file_info["file_size"] = file_path_obj.stat().st_size
+          result["successful_writes"] += 1
+        else:
+          file_info["error"] = "File was not created successfully"
+          result["success"] = False
+
+      except Exception as e:
+        file_info["error"] = f"Write failed: {str(e)}"
+        result["success"] = False
+
+      result["files"][str(file_path_obj)] = file_info
+
+    return result
+
+  except Exception as e:
+    return {
+        "success": False,
+        "files": {},
+        "successful_writes": 0,
+        "total_files": len(files) if files else 0,
+        "errors": [f"Write operation failed: {str(e)}"],
+    }


### PR DESCRIPTION
## Summary
- add sample `software_agent` with sequential pipeline to generate code, build and run Docker image
- implement `write_files`, `docker_build`, and `run_command` tools under `software_agent/tools`
- document pipeline and tools in new README

## Testing
- `./autoformat.sh` *(fails: pyink not found)*
- `pytest tests/unittests` *(fails: Interrupted: 178 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bff9f34fcc8320823004e84e33ec2f